### PR TITLE
Add persistent log and post-relay retest workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 result.json
 results.csv
+connection_log.csv


### PR DESCRIPTION
## Summary
- add connection_log.csv management and append entries with timestamp, MAC, IP, and test result
- generate structured test reports reused for email body and saved to the new log file
- trigger relay with configurable delay, wait for connectivity to return, and rerun the tests after the reset
- attach the incremental log file to the email report and include both test passes in the email body

## Testing
- python -m compileall monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a39a0a84832f879dcbed1de6bc60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CSV connection logging with IP/MAC, refactors tests into reusable reports used in emails, introduces relay delay + connectivity wait, performs post-reset tests, and attaches the log to emails.
> 
> - **Logging & Reporting**:
>   - Add `connection_log.csv` management (`LOG_FILE`), with helpers `ensure_log_file` and `append_log_entry` writing `timestamp;mac;ip;resultado`.
>   - New `perform_speed_tests()` composes ping + Ookla + JS results, captures IP via `get_ip_address()`, logs entries, and returns structured report used in email body.
> - **Relay & Workflow**:
>   - `reset_modem()` now returns success flag and logs actions; CLI adds `--relay-delay-seconds`.
>   - After relay, wait for connectivity (timeout based on delay) and run a second test pass ("Teste pós-reset").
> - **Email & Attachments**:
>   - Email body now includes both test passes and recent log entries; attaches `ookla_result.json`, JS `result.json`, `results.csv`, and `connection_log.csv`.
> - **Misc**:
>   - Update `.gitignore` to ignore `connection_log.csv`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dd2be6bbc1ead1df0f83c4e278280521c38a3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->