### PR TITLE
Guard GPIO operations when relay is disabled

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -444,19 +444,21 @@ def main():
     gpio_ready = False
     if not args.no_relay:
         gpio_ready = maybe_setup_gpio(args.relay_pin)
+    if gpio_ready and GPIO:
 #----------------> @@@Alterado 28/09
 #"Reset" GPIO - limpa e monta - Solucao para disparo do rele no "start"
-    GPIO.cleanup()
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setup(17, GPIO.OUT)
+        GPIO.cleanup()
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(args.relay_pin, GPIO.OUT)
 #<---------------------------------##
     js_path = Path(args.js)
     result_json_path = Path(args.json)
 
     while True:
+        if gpio_ready and GPIO and not args.no_relay:
 #----------------> @@@Alterado 28/09
 #"Limpa" GPIO - Desliga o rele (Reativa ONT)
-        GPIO.cleanup()
+            GPIO.cleanup()
 #Espera xx tempo reinicializacao ONT
         time.sleep(180)
 #<---------------------------------##
@@ -473,9 +475,9 @@ def main():
         reports.append(perform_speed_tests("Teste após MAC", mac, js_path, result_json_path))
 
         # 3) Reset modem (mantido)
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(17, GPIO.OUT)
-        if gpio_ready and not args.no_relay:
+        if gpio_ready and GPIO and not args.no_relay:
+            GPIO.setmode(GPIO.BCM)
+            GPIO.setup(args.relay_pin, GPIO.OUT)
             print("🔄 Resetando modem via relé ...")
             try:
                 acionou = reset_modem(args.relay_pin, pulse_seconds=float(max(args.relay_delay_seconds, 0)), active_high=True)


### PR DESCRIPTION
## Summary
- ensure the GPIO reset/setup logic only runs when the relay is enabled and the GPIO module initialized
- guard the main loop's GPIO cleanup and modem reset preparation so that --no-relay skips all GPIO accesses

## Testing
- not run (RPi.GPIO dependency is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd4848b9b8832f95c26cb01821de56